### PR TITLE
Fix Focus Local: slow vertical lab transfer and slow Graviton Lens intake

### DIFF
--- a/SampleAndHoldSim/src/Logic/ThreadManager_Patch.cs
+++ b/SampleAndHoldSim/src/Logic/ThreadManager_Patch.cs
@@ -43,6 +43,7 @@ namespace SampleAndHoldSim
                 {
                     case EGameLogicTask.FactoryLabOutput: // 1800
                         AfterTransport();
+                        GameTick_Patch.FixLocalLabOutput();
                         break;
                 }
             }


### PR DESCRIPTION
## Fix Focus Local: slow vertical lab transfer and slow Graviton Lens intake

### Problem

When **Focus Local** is enabled with a high **UpdatePeriod**, two bugs affect the focused (local) planet:

1. **Vertical lab stacking**: Materials transfer between stacked labs (self-evolution/matrix labs) at `1/UpdatePeriod` the expected rate, causing upper labs to starve.
2. **Graviton Lens intake**:  Ray receivers accept Graviton Lenses far too slowly, only checking for lens intake every `10 × UpdatePeriod` ticks instead of every 10 ticks, causing receivers to operate without lenses most of the time.

Both bugs share the same root cause: `GameLogic_Patch.OnFactoryBegin` divides `GameLogic.timei` by `UpdatePeriod` globally for all factories. The focused local factory runs every tick but receives this divided `timei`, breaking time-dependent modulo operations.

### Root Cause Analysis

#### Bug 1: Vertical lab transfer

`GameLogic._lab_output_to_next_parallel` (the multi-threaded path used by most players) computes `num2 = (int)(this.timei & 3L)` once before iterating factories. This determines which 1/4 of labs run `UpdateOutputToNext` each tick. With divided `timei`, `num2` changes every `UpdatePeriod` ticks instead of every tick, so the local factory's labs transfer in bursts of `UpdatePeriod` consecutive ticks followed by `3 × UpdatePeriod` ticks of no transfer — instead of the vanilla round-robin pattern.

Note: The existing transpiler on `FactorySystem.GameTickLabOutputToNext` (the single-threaded path) already fixes this via `GetGameTick()`, but the multi-threaded path which was unpatched.

#### Bug 2: Graviton Lens

`PowerSystem.GameTick` receives `this.timei` (already divided) as the `time` parameter. At line 1385: `bool useCata = time % 10L == 0L`. This flag controls when ray receivers attempt to intake a Graviton Lens from their inventory. With `time = gameTick / UpdatePeriod`, the check only passes every `10 × UpdatePeriod` real ticks instead of every 10 ticks. For example, with `UpdatePeriod = 10`, lenses are only pulled in every 100 ticks — the receiver sits idle without a lens for 90% of the time.

The existing `PowerSystem_Gametick` prefix only corrects `time` for `IsNextIdle` factories (remote planets about to go idle), but the focused local factory (`IsNextIdle = false`) received no correction.

### Fix

#### Bug 1: Corrective pass after parallel lab output (`GameTick_Patch.FixLocalLabOutput`)

A corrective pass runs on the **main thread** after `phaseBarrier.SignalAndWait()` in `ThreadManager_Patch.OnPhaseEnd` — guaranteeing all parallel threads have completed. It:

1. Computes `correctNum = GameMain.gameTick & 3L` (what vanilla would use)
2. Computes `wrongNum = (GameMain.gameTick / UpdatePeriod) & 3L` (what the parallel method used)
3. Early-exits if they match (no correction needed)
4. Runs `UpdateOutputToNext` for local factory labs where `(index & 3) == correctNum`

This is safe because `UpdateOutputToNext` is idempotent when there's no excess material (threshold check: `matrixServed >= 7200`), so labs that already transferred via `wrongNum` in the parallel pass are unaffected.

#### Bug 2: Restore real time for focused factory (`PowerSystem_Gametick` prefix)

Added `else if` branch: when the factory is the focused local factory, set `time = GameMain.gameTick`. This restores vanilla behavior for all time-dependent modulo checks in `PowerSystem.GameTick` (`useCata`, wind/solar update intervals, etc.).

### Files changed

- **`GameTick_Patch.cs`**: Added `FixLocalLabOutput()` method and `else if` branch in `PowerSystem_Gametick`
- **`ThreadManager_Patch.cs`**: Call `FixLocalLabOutput()` in `OnPhaseEnd` after `FactoryLabOutput` phase completes
